### PR TITLE
Adjusting section 0 header display and adding new option.

### DIFF
--- a/lang/en/format_collapsibletopics.php
+++ b/lang/en/format_collapsibletopics.php
@@ -38,4 +38,6 @@ $string['privacy:request:preference:sectionstoggle'] = 'You kept sections {$a->v
 $string['sectionname'] = 'Topic';
 $string['section0name'] = 'General';
 $string['showfromothers'] = 'Show topic';
-
+$string['showsection0'] = 'Show section 0 section title';
+$string['section0titlehidden'] = 'Section 0 title is hidden';
+$string['section0titleshown'] = 'Section 0 title is shown';

--- a/lib.php
+++ b/lib.php
@@ -220,6 +220,10 @@ class format_collapsibletopics extends format_base {
                     'default' => $courseconfig->hiddensections,
                     'type' => PARAM_INT,
                 ),
+                'showsection0title' => array(
+                    'default' => $courseconfig->showsection0title,
+                    'type' => PARAM_INT,
+                )
             );
         }
         if ($foreditform && !isset($courseformatoptions['hiddensections']['label'])) {
@@ -235,6 +239,16 @@ class format_collapsibletopics extends format_base {
                             1 => new lang_string('hiddensectionsinvisible')
                         )
                     ),
+                ),
+                'showsection0title' => array(
+                    'label' => get_string('showsection0', 'format_collapsibletopics'),
+                    'element_type' => 'select',
+                    'element_attributes' => array(
+                        array(
+                          0 => get_string('section0titlehidden', 'format_collapsibletopics'),
+                          1 => get_string('section0titleshown', 'format_collapsibletopics'),
+                        )
+                    )
                 ),
             );
             $courseformatoptions = array_merge_recursive($courseformatoptions, $courseformatoptionsedit);

--- a/renderer.php
+++ b/renderer.php
@@ -270,9 +270,10 @@ class format_collapsibletopics_renderer extends format_section_renderer_base {
                     $section->section .
                     '">&nbsp;' . $sectionname .
                     '</a> ';
+            } else if ($section->section == 0 && $course->showsection0title == True && !is_null($section->name)) {
+                $o .= $this->output->heading($sectionname, 3, 'sectionname' . $classes);
             }
             // End collapse toggle.
-
             $o .= '<div class="clearfix">';
             $o .= $this->section_availability($section) . '</div>';
             if ($section->uservisible || $section->visible) {


### PR DESCRIPTION
This pull request adjusts the behaviour of the course format so the visibility of section 0 header is consistent with topics format.  This is intended to fix #1 

It also adds an option to show/hide the section 0 header.

Interesting in others testing that the behaviour is consistent with topics format, and if the additional option is necessary.  