### PR TITLE
Fixed faulty data-parent=".accordion" selector

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -266,7 +266,7 @@ class format_collapsibletopics_renderer extends format_section_renderer_base {
                     $o .= $this->section_progressbar($total, $complete);
                 }
                 $o .= '<a class="sectiontoggle' .
-                    '" data-toggle="collapse" data-parent="accordion" href="#collapse-' .
+                    '" data-toggle="collapse" data-parent=".accordion" href="#collapse-' .
                     $section->section .
                     '" aria-expanded="true" aria-controls="collapse-' .
                     $section->section .
@@ -276,7 +276,7 @@ class format_collapsibletopics_renderer extends format_section_renderer_base {
                     $o .= $this->section_progressbar($total, $complete);
                 }
                 $o .= '<a class="sectiontoggle collapsed' .
-                    '" data-toggle="collapse" data-parent="accordion" href="#collapse-' .
+                    '" data-toggle="collapse" data-parent=".accordion" href="#collapse-' .
                     $section->section .
                     '" aria-expanded="false" aria-controls="collapse-' .
                     $section->section .
@@ -302,14 +302,14 @@ class format_collapsibletopics_renderer extends format_section_renderer_base {
             // Add collapse toggle.
             if (course_get_format($course)->is_section_current($section)) {
                 $o .= '<a class="sectiontoggle' .
-                    '" data-toggle="collapse" data-parent="accordion" href="#collapse-' .
+                    '" data-toggle="collapse" data-parent=".accordion" href="#collapse-' .
                     $section->section .
                     '" aria-expanded="true" aria-controls="collapse-' .
                     $section->section .
                     '">&nbsp;</a> ';
             } else if ($section->section != 0) {
                 $o .= '<a class="sectiontoggle collapsed' .
-                    '" data-toggle="collapse" data-parent="accordion" href="#collapse-' .
+                    '" data-toggle="collapse" data-parent=".accordion" href="#collapse-' .
                     $section->section .
                     '" aria-expanded="false" aria-controls="collapse-' .
                     $section->section .


### PR DESCRIPTION
Since Bootstrap 4.1.3, setting a faulty selector as data-parent causes a JavaScript error. See also: https://stackoverflow.com/questions/52411316/cannot-read-property-queryselectorall-of-null-bootstrap-collapse In some cases, this prevented sections to open (for students only). Hence, this PR fixes the selector.